### PR TITLE
Fix cardClasses and add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,22 @@ This extension makes the github projects page work like Trello does.
 Going to a link with a hash inside it will open the corresponding ticket.
 
 These hashes can be ticket number or card id.
+
+
+## Usage
+
+0. Clone or download this repository
+!["Clone or Download" button](https://i.imgur.com/5oKbwF6.png)
+
+1. Go to [chrome://extensions](chrome://extensions) and enable Developer mode.
+![Enabling "Developer mode"](https://i.imgur.com/fJol7q4.png)
+
+2. Click "Load unpacked extension" and select the folder containing this repository.
+![Load unpacked extension](https://i.imgur.com/NSKaeWK.png)
+![Browse and select parent folder](https://i.imgur.com/3DU9QSU.png)
+
+3. Ensure extension appears in list
+![Extension displayed and enabled](https://i.imgur.com/yVyMMAG.png)
+
+4. Go to a GitHub Project and click on a card link
+![Voilà!](https://i.imgur.com/1P83e6I.png)

--- a/gitlo.js
+++ b/gitlo.js
@@ -48,7 +48,7 @@ chrome.storage.sync.get(settings, function(items){
   }
 });
 
-var cardClasses = ".issue-card h5 > a, .project-card h5 > a";
+var cardClasses = ".issue-card a.h5, .project-card a.h5";
 var urlBase = "https://github.com";
 
 var cardModal = '<div class="modal" style="display: none"></div>';


### PR DESCRIPTION
Probably duplicating the work of #18, but specify `a.h5` in addition to removing the `<h5>` tag expectation.

Also, adding some installation instructions in case they'd be useful.